### PR TITLE
Homepage Buildots logo and lazy-load podcast embeds

### DIFF
--- a/src/components/results/index.jsx
+++ b/src/components/results/index.jsx
@@ -1,10 +1,56 @@
-import {useState, useEffect} from 'preact/hooks';
+import {useState, useEffect, useRef, useMemo} from 'preact/hooks';
 import styles from './styles.module.scss';
 import classNames from 'classnames/bind';
 import results from './data';
 import podcast from '../../assets/icons/microphone.svg';
 
 const cn = classNames.bind(styles);
+const PODCASTS_BATCH = 10;
+
+function embedSrc(url) {
+    return `${url}${url.includes('?') ? '&' : '?'}utm_source=generator&theme=0`;
+}
+
+function PodcastEmbed({url}) {
+    const containerRef = useRef(null);
+    const [src, setSrc] = useState(null);
+
+    useEffect(() => {
+        const el = containerRef.current;
+        if (!el || src) return;
+
+        const observer = new IntersectionObserver(
+            ([entry]) => {
+                if (entry.isIntersecting) {
+                    setSrc(embedSrc(url));
+                    observer.disconnect();
+                }
+            },
+            {rootMargin: '200px 0px'}
+        );
+
+        observer.observe(el);
+        return () => observer.disconnect();
+    }, [url, src]);
+
+    return (
+        <div ref={containerRef} className={styles.podcastEmbed}>
+            {src ? (
+                <iframe
+                    style="border-radius:16px"
+                    src={src}
+                    width="100%"
+                    height="152"
+                    frameBorder="0"
+                    allowfullscreen=""
+                    allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture"
+                />
+            ) : (
+                <div className={styles.podcastPlaceholder} aria-hidden="true" />
+            )}
+        </div>
+    );
+}
 
 export const tags = [
     {name: 'Highlights', value: 'highlights'},
@@ -24,11 +70,57 @@ export default function Results({tag}) {
     const [value, setValue] = useState(tag || 'highlights');
     const [isEditMode, setIsEditMode] = useState(false);
     const [hiddenCards, setHiddenCards] = useState(new Set());
+    const [visiblePodcastCount, setVisiblePodcastCount] = useState(PODCASTS_BATCH);
+    const loadMoreRef = useRef(null);
 
     useEffect(() => {
         const searchParams = new URLSearchParams(window.location.search);
         setIsEditMode(searchParams.get('edit') === 'true');
     }, []);
+
+    useEffect(() => {
+        if (value === 'podcasts') {
+            setVisiblePodcastCount(PODCASTS_BATCH);
+        }
+    }, [value]);
+
+    const filteredResults = useMemo(
+        () => results
+            .filter(({tags}) => !value || tags.includes(value))
+            .filter(({url}) => !hiddenCards.has(url)),
+        [value, hiddenCards]
+    );
+
+    const paginatePodcasts = value === 'podcasts' && !isEditMode;
+    const displayedResults = useMemo(
+        () => paginatePodcasts
+            ? filteredResults.slice(0, visiblePodcastCount)
+            : filteredResults,
+        [filteredResults, paginatePodcasts, visiblePodcastCount]
+    );
+
+    const hasMorePodcasts = paginatePodcasts && visiblePodcastCount < filteredResults.length;
+
+    useEffect(() => {
+        if (!hasMorePodcasts) return;
+
+        const el = loadMoreRef.current;
+        if (!el) return;
+
+        const observer = new IntersectionObserver(
+            ([entry]) => {
+                if (entry.isIntersecting) {
+                    setVisiblePodcastCount((count) =>
+                        Math.min(count + PODCASTS_BATCH, filteredResults.length)
+                    );
+                }
+            },
+            {rootMargin: '400px 0px'}
+        );
+
+        observer.observe(el);
+        return () => observer.disconnect();
+    }, [hasMorePodcasts, filteredResults.length, visiblePodcastCount]);
 
     const hideCard = (url) => {
         setHiddenCards(prev => new Set([...prev, url]));
@@ -37,33 +129,48 @@ export default function Results({tag}) {
     return (
         <>
             <div className={styles.tags}>
-                {visibleTags.map(({name, value: val, icon}) => <button className={cn('tag', {active: value == val})} onClick={() => setValue(val)}>{icon ? <img class='social-icon' src={podcast.src} alt="podcast mic icon"></img> : null}{name}</button>)}
+                {visibleTags.map(({name, value: val, icon}) => (
+                    <button
+                        key={val}
+                        type="button"
+                        className={cn('tag', {active: value == val})}
+                        onClick={() => setValue(val)}
+                    >
+                        {icon ? <img class="social-icon" src={podcast.src} alt="podcast mic icon" /> : null}
+                        {name}
+                    </button>
+                ))}
             </div>
-            <div className={cn(styles.resultsWrapper, { [styles.editMode]: isEditMode })}>
-                {results
-                    .filter(({tags}) => !value || tags.includes(value))
-                    .filter(({url}) => !hiddenCards.has(url))
-                    .map(({url, logo, headline, publication, date, tags, embed = true}) => {
-                        const isEmbeddedPodcast = tags.includes('podcasts') && embed !== false;
-                        const isExternalPodcast = tags.includes('podcasts') && embed === false;
+            <div className={cn(styles.resultsWrapper, {[styles.editMode]: isEditMode})}>
+                {displayedResults.map(({url, logo, headline, publication, date, tags, embed = true}) => {
+                    const isEmbeddedPodcast = tags.includes('podcasts') && embed !== false;
+                    const isExternalPodcast = tags.includes('podcasts') && embed === false;
 
-                        return (
-                            <li className={cn("result-card", {podcast: isEmbeddedPodcast, externalPodcast: isExternalPodcast})} key={url}>
-                                {isEditMode && <button className={styles.deleteButton} onClick={() => hideCard(url)}>×</button>}
-                                {
-                                    isEmbeddedPodcast
-                                    ? <iframe style="border-radius:16px" src={`${url}${url.includes('?') ? '&' : '?'}utm_source=generator&theme=0`} width="100%" height="152" frameBorder="0" allowfullscreen="" allow="autoplay; clipboard-write; encrypted-media; fullscreen; picture-in-picture" loading="lazy"></iframe>
-                                    : (
-                                        <a href={url} target="_blank">
-                                            {logo && <img src={logo.src} alt={`${publication} logo`}/>}
-                                            <h4>{headline}</h4>
-                                            <p>{date}</p>
-                                        </a>
-                                    )
-                                }
-                            </li>
-                        );
-                    })}
+                    return (
+                        <li
+                            className={cn('result-card', {podcast: isEmbeddedPodcast, externalPodcast: isExternalPodcast})}
+                            key={url}
+                        >
+                            {isEditMode && (
+                                <button type="button" className={styles.deleteButton} onClick={() => hideCard(url)}>
+                                    ×
+                                </button>
+                            )}
+                            {isEmbeddedPodcast ? (
+                                <PodcastEmbed url={url} />
+                            ) : (
+                                <a href={url} target="_blank" rel="noreferrer">
+                                    {logo && <img src={logo.src} alt={`${publication} logo`} />}
+                                    <h4>{headline}</h4>
+                                    <p>{date}</p>
+                                </a>
+                            )}
+                        </li>
+                    );
+                })}
+                {hasMorePodcasts && (
+                    <li ref={loadMoreRef} className={styles.loadMoreSentinel} aria-hidden="true" />
+                )}
             </div>
         </>
     );

--- a/src/components/results/styles.module.scss
+++ b/src/components/results/styles.module.scss
@@ -164,4 +164,24 @@
         max-height: 30px;
         max-width: 200px;
     }
+
+    .podcastEmbed {
+        min-height: 152px;
+    }
+
+    .podcastPlaceholder {
+        background: #f8fafc;
+        border-radius: 16px;
+        height: 152px;
+        width: 100%;
+    }
+
+    .loadMoreSentinel {
+        flex: 0 0 100%;
+        height: 1px;
+        list-style: none;
+        margin: 0;
+        padding: 0;
+        visibility: hidden;
+    }
 }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -73,7 +73,7 @@ const results = [
 				<LinkButton href="/clients" type='hollow'>See all our clients</LinkButton>
 			</div>
 			<div class="logos">
-				<a class="client" href="https://buildots.com/" target="_blank"><img src={buildots.src} alt="buildots logo"/></a>
+				<a class="client" href="https://buildots.com/" target="_blank"><img class="buildots-logo" src={buildots.src} alt="buildots logo"/></a>
 				<a class="client" href="https://www.band.ai/" target="_blank"><img src={band.src} alt="BAND logo"/></a>
 				<a class="client" href="https://scaleops.com/" target="_blank"><img src={scaleops.src} alt="ScaleOps logo"/></a>
 				<a class="client" href="https://www.datarails.com/" target="_blank"><img class="datarails-logo" src={datarails.src} alt="Datarails logo"/></a>
@@ -227,6 +227,14 @@ const results = [
 		height: auto;
 		max-height: 50px;
 		max-width: 145px;
+	}
+
+	/* Match /clients: wide logo is width-constrained (184px in 280px card → 116px in 176px card) */
+	.client img.buildots-logo {
+		width: 116px;
+		max-width: 116px;
+		max-height: 48px;
+		height: auto;
 	}
 
 	#results {


### PR DESCRIPTION
## Summary

- Match homepage Buildots logo proportions to the `/clients` page (`buildots-logo` sizing on the client strip).
- Podcasts tab on `/results`: show 10 cards on load, load 10 more on scroll, and set Apple Podcast iframe `src` only when cards enter the viewport (reduces initial embed load).

## Test plan

- [ ] Homepage client strip: Buildots logo proportions match `/clients`
- [ ] `/results/podcasts`: ~10 cards on load; more appear when scrolling down
- [ ] DevTools: few `embed.podcasts.apple.com` requests until scrolling
- [ ] `/results` Highlights tab unchanged
- [ ] `?edit=true` still shows all podcast cards


Made with [Cursor](https://cursor.com)